### PR TITLE
api changes (may not be good changes....)

### DIFF
--- a/dbi.asd
+++ b/dbi.asd
@@ -18,7 +18,8 @@
   :version "0.1"
   :author "Eitarow Fukamachi"
   :license "LLGPL"
-  :depends-on (:cl-syntax
+  :depends-on (:alexandria
+               :cl-syntax
                :cl-syntax-annot
                :split-sequence
                :closer-mop)

--- a/src/dbd/postgres.lisp
+++ b/src/dbd/postgres.lisp
@@ -55,22 +55,22 @@
                :message (database-error-message e)
                :error-code (database-error-code e))))))
 
-(defmethod execute-using-connection ((conn <dbd-postgres-connection>) (query <dbd-postgres-query>) params)
-  (exec-prepared (connection-handle conn)
+(defmethod execute ((query <dbd-postgres-query>) params)
+  (exec-prepared (connection-handle (query-connection query))
                  (slot-value query 'name)
                  params
                  ;; TODO: lazy fetching
                  (row-reader (fields)
                    (let ((result
                           (loop while (next-row)
-                                collect (loop for field across fields
-                                              collect (intern (field-name field) :keyword)
-                                              collect (next-field field)))))
+                             collect (loop for field across fields
+                                        collect (intern (field-name field) :keyword)
+                                        collect (next-field field)))))
                      (setf (slot-value query '%result)
                            result)
                      query))))
 
-(defmethod fetch ((query <dbd-postgres-query>))
+(defmethod fetch-next ((query <dbd-postgres-query>))
   (pop (slot-value query '%result)))
 
 (defmethod disconnect ((conn <dbd-postgres-connection>))

--- a/src/dbi.lisp
+++ b/src/dbi.lisp
@@ -15,7 +15,7 @@
                 :disconnect
                 :prepare
                 :execute
-                :fetch
+                :fetch-next
                 :fetch-all
                 :do-sql
                 :begin-transaction
@@ -26,7 +26,7 @@
            :disconnect
            :prepare
            :execute
-           :fetch
+           :fetch-next
            :fetch-all
            :do-sql
            :begin-transaction

--- a/src/dbi.lisp
+++ b/src/dbi.lisp
@@ -17,6 +17,7 @@
                 :execute
                 :fetch-next
                 :fetch-all
+                :result-set-column-names
                 :do-sql
                 :begin-transaction
                 :commit
@@ -28,6 +29,7 @@
            :execute
            :fetch-next
            :fetch-all
+           :result-set-column-names
            :do-sql
            :begin-transaction
            :commit

--- a/src/dbi.lisp
+++ b/src/dbi.lisp
@@ -51,6 +51,7 @@
 @export
 (defun connect (driver-name &rest params &key database-name &allow-other-keys)
   "Open a connection to the database which corresponds to `driver-name`."
+  (declare (ignore database-name))
   (let ((driver (find-driver driver-name)))
     (unless driver
       (load-driver driver-name)

--- a/src/driver.lisp
+++ b/src/driver.lisp
@@ -15,7 +15,9 @@
                 :<dbi-notsupported-error>)
   (:export :connection-handle
            :query-connection
-           :query-prepared))
+           :query-prepared
+           :result-set-query
+           :result-set-column-names))
 (in-package :dbi.driver)
 
 (cl-syntax:use-syntax :annot)
@@ -91,7 +93,14 @@ Driver should be named like '<DBD-SOMETHING>' for a database 'something'."
   (:documentation "Class that represents a prepared DB query."))
 
 @export
-(defgeneric prepare (conn sql &key &allow-other-keys)
+(defclass <dbi-query-result-set> ()
+  ((query :initarg :query :accessor result-set-query)))
+
+(define-dbi-interface result-set-column-names (<dbi-query-result-set>)
+  "Names, according to the underlying database, of the columns in the result set.")
+
+@export
+(defgeneric prepare (<dbi-connection> sql &key &allow-other-keys)
   (:documentation "Preparing executing SQL statement and returns a instance of `<dbi-query>`.
 This method may be overrided by subclasses.")
   (:method ((conn <dbi-connection>) (sql string) &key &allow-other-keys)
@@ -99,7 +108,7 @@ This method may be overrided by subclasses.")
                    :connection conn
                    :prepared (prepare-sql conn sql))))
 
-(define-dbi-interface fetch-next (<dbi-query>)
+(define-dbi-interface fetch-next (<dbi-query-result-set>)
   "Fetch the next row from `query` which is returned by `execute`.")
 
 @export

--- a/src/driver.lisp
+++ b/src/driver.lisp
@@ -99,23 +99,13 @@ This method may be overrided by subclasses.")
                    :connection conn
                    :prepared (prepare-sql conn sql))))
 
-@export
-(defmethod execute ((query <dbi-query>) &rest params)
-  "Execute `query` with `params` and return the results."
-  (execute-using-connection
-   (query-connection query)
-   query
-   params))
-
-@export
-(defmethod fetch ((query <dbi-query>))
-  "Fetch the first row from `query` which is returned by `execute`."
-  (fetch-using-connection (query-connection query) query))
+(define-dbi-interface fetch-next (<dbi-query>)
+  "Fetch the next row from `query` which is returned by `execute`.")
 
 @export
 (defmethod fetch-all ((query <dbi-query>))
   "Fetch all rest rows from `query`."
-  (loop for result = (fetch query)
+  (loop for result = (fetch-next query)
         while result
         collect result))
 
@@ -129,8 +119,8 @@ This method may be overrided by subclasses."
   (apply #'execute (prepare conn sql) params)
   nil)
 
-(define-dbi-interface execute-using-connection (<dbi-connection> <dbi-query> params)
-  "Execute `query` in `conn` with query parameters bound to the values PARAMS.")
+(define-dbi-interface execute (<dbi-query> params)
+  "Execute `query`with query parameters bound to the values PARAMS.")
 
 (define-dbi-interface begin-transaction (<dbi-connection>)
   "Start a transaction.")


### PR DESCRIPTION
1. added a result-set class so we can 'cache' the computing of the column names
2. removed the -using-class methods since the query already knows its type
3. added a macro, define-dbi-interface, to create "interface" methods
