### PR TITLE
Add sqlite3 busy-timeout option

### DIFF
--- a/src/dbd/sqlite3.lisp
+++ b/src/dbd/sqlite3.lisp
@@ -21,9 +21,9 @@
 @export
 (defclass <dbd-sqlite3-connection> (<dbi-connection>) ())
 
-(defmethod make-connection ((driver <dbd-sqlite3>) &key database-name)
+(defmethod make-connection ((driver <dbd-sqlite3>) &key database-name busy-timeout)
   (make-instance '<dbd-sqlite3-connection>
-     :handle (connect database-name)))
+     :handle (connect database-name :busy-timeout busy-timeout)))
 
 (defmethod prepare ((conn <dbd-sqlite3-connection>) (sql string) &key)
   (handler-case


### PR DESCRIPTION
cl-dbi not support busy-timeout option for sqlite.
if not use this option, cl-sqlite returned busy error frequently.

see also
http://common-lisp.net/project/cl-sqlite/#connect
