### PR TITLE
Replace osicat for uiop

### DIFF
--- a/dbd-sqlite3.asd
+++ b/dbd-sqlite3.asd
@@ -22,7 +22,7 @@
                :sqlite
                :cl-syntax
                :cl-syntax-annot
-               :osicat)
+               :uiop)
   :components ((:module "src/dbd"
                 :components
                 ((:file "sqlite3"))))

--- a/src/dbd/sqlite3.lisp
+++ b/src/dbd/sqlite3.lisp
@@ -11,8 +11,8 @@
         :sqlite)
   (:shadowing-import-from :dbi.driver
                           :disconnect)
-  (:import-from :osicat
-                :regular-file-exists-p))
+  (:import-from :uiop/filesystem
+                :file-exists-p))
 (in-package :dbd.sqlite3)
 
 (cl-syntax:use-syntax :annot)
@@ -83,5 +83,5 @@
          (database-path (sqlite::database-path handle)))
     (cond
       ((string= database-path ":memory:") T)
-      ((osicat:regular-file-exists-p database-path) T)
+      ((uiop:file-exists-p database-path) T)
       (T nil))))


### PR DESCRIPTION
   replace osicat's regular-file-exists-p for uiop's
   (formerly known as asdf-driver) file-exists-p which is more portable.

Relaed to: https://github.com/fukamachi/cl-dbi/issues/12
