### PR TITLE
Savepoint support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -67,6 +67,9 @@ This library will be available on Quicklisp when ready for use.
 * begin-transaction [conn]
 * commit [conn]
 * rollback [conn]
+* savepoint [conn savepoint-name]
+* release-savepoint [conn savepoint-name]
+* rollback-to-savepoint [conn savepoint-name]
 * ping [conn] =&gt; T or NIL
 * row-count [conn] =&gt a number of rows modified by the last executed INSERT/UPDATE/DELETE
 * with-connection [connection-variable-name &body body]
@@ -85,8 +88,11 @@ This library will be available on Quicklisp when ready for use.
 * begin-transaction [conn]
 * commit [conn]
 * rollback [conn]
+* savepoint [conn savepoint-name]
+* release-savepoint [conn savepoint-name]
+* rollback-to-savepoint [conn savepoint-name]
 * ping [conn] =&gt; T or NIL
-* row-count [conn] =&gt a number of rows modified by the last executed INSERT/UPDATE/DELETE
+* row-count [conn] =&gt; a number of rows modified by the last executed INSERT/UPDATE/DELETE
 
 ## Creating a new driver
 
@@ -102,6 +108,9 @@ These methods can be overriden if needed.
 * fetch-using-connection
 * do-sql
 * escape-sql
+* savepoint
+* release-savepoint
+* rollback-to-savepoint
 
 ## Dependencies
 

--- a/src/driver.lisp
+++ b/src/driver.lisp
@@ -177,6 +177,39 @@ This method must be implemented in each drivers.")
            :method-name 'rollback)))
 
 @export
+(defgeneric savepoint (conn savepoint-name)
+  (:documentation
+    "Set a named transaction savepoint with a name of `savepoint-name`.
+This method may be overrided by subclasses.")
+  (:method ((conn <dbi-connection>)
+            (savepoint-name string))
+   (let* ((sql (format nil "SAVEPOINT ~a"
+                       (escape-sql conn savepoint-name))))
+     (do-sql conn sql))))
+
+@export
+(defgeneric release-savepoint (conn savepoint-name)
+  (:documentation
+    "Release transaction savepoint `savepoint-name`.
+This method may be overrided by subclasses.")
+  (:method ((conn <dbi-connection>)
+            (savepoint-name string))
+   (let* ((sql (format nil "RELEASE SAVEPOINT ~a"
+                       (escape-sql conn savepoint-name))))
+     (do-sql conn sql))))
+
+@export
+(defgeneric rollback-to-savepoint (conn savepoint-name)
+  (:documentation
+    "Rollback all changes since `savepoint-name`.
+This method may be overrided by subclasses.")
+  (:method ((conn <dbi-connection>)
+            (savepoint-name string))
+   (let* ((sql (format nil "ROLLBACK TO SAVEPOINT ~a"
+                       (escape-sql conn savepoint-name))))
+     (do-sql conn sql))))
+
+@export
 (defgeneric ping (conn)
   (:documentation
    "Check if the database server is still running and the connection to it is still working.")


### PR DESCRIPTION
Added methods:
- `savepoint`
- `release-savepoint`
- `rollback-to-savepoint`

Savepoints are identified as `string`s, no savepoint class (yet?). Manually tested against MySQL and Sqlite3, syntax suspected to be compatible with PostgreSQL. CI tests not added yet.
