### PR TITLE
PostgreSQL requires to free prepared statements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ env:
     - LISP=ccl-bin
     - LISP=clisp
 
+matrix:
+  allow_failures:
+    - env: LISP=clisp
+
 install:
   # Install Roswell
   - curl -L https://raw.githubusercontent.com/roswell/roswell/release/scripts/install-for-ci.sh | sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,10 @@ language: common-lisp
 sudo: false
 
 addons:
-  postgresql: "9.3"
+  postgresql: "9.4"
+
+services:
+  - postgresql
 
 env:
   global:
@@ -15,7 +18,7 @@ env:
 
 install:
   # Install Roswell
-  - curl -L https://raw.githubusercontent.com/snmsts/roswell/release/scripts/install-for-ci.sh | sh
+  - curl -L https://raw.githubusercontent.com/roswell/roswell/release/scripts/install-for-ci.sh | sh
   - ros install prove
 
 before_script:
@@ -23,7 +26,6 @@ before_script:
   - mysql -e 'CREATE DATABASE `cl-dbi`'
   - psql -c 'create database "cl-dbi";' -U postgres
   - psql -c "CREATE USER nobody WITH PASSWORD 'nobody';" -U postgres
-  - git clone -b in-package-cl-user https://github.com/fukamachi/cl-annot ~/lisp/cl-annot
 
 script:
   - run-prove dbi-test.asd

--- a/dbd-postgres.asd
+++ b/dbd-postgres.asd
@@ -20,6 +20,7 @@
   :license "LLGPL"
   :depends-on (:dbi
                :cl-postgres
+               :trivial-garbage
                :cl-syntax
                :cl-syntax-annot)
   :components ((:module "src/dbd"


### PR DESCRIPTION
PostgreSQL's prepared statements don't disappear implicitly.
Which means, PostgreSQL driver could take much memory while reusing a connection.

This change calls `unprepare-query` before the prepared statement is going to be reclaimed by a garbage collector.