### PR TITLE
Add SQL logging

### DIFF
--- a/dbi.asd
+++ b/dbi.asd
@@ -25,8 +25,9 @@
                :bordeaux-threads)
   :components ((:module "src"
                 :components
-                ((:file "dbi" :depends-on ("driver"))
+                ((:file "dbi" :depends-on ("driver" "logger"))
                  (:file "driver" :depends-on ("error"))
+                 (:file "logger")
                  (:file "error"))))
   :description "Database independent interface for Common Lisp"
   :long-description

--- a/src/dbd/postgres.lisp
+++ b/src/dbd/postgres.lisp
@@ -134,9 +134,11 @@
 
 (defmethod do-sql ((conn <dbd-postgres-connection>) sql &rest params)
   (if params
-      (call-next-method)
+      (progn
+        (call-next-method)
+        (row-count conn))
       (with-handling-pg-errors
-        (exec-query (connection-handle conn) sql))))
+        (or (nth-value 1 (exec-query (connection-handle conn) sql)) 0))))
 
 (defmethod disconnect ((conn <dbd-postgres-connection>))
   (close-database (connection-handle conn)))

--- a/src/dbd/postgres.lisp
+++ b/src/dbd/postgres.lisp
@@ -2,6 +2,7 @@
 (defpackage dbd.postgres
   (:use :cl
         :dbi.driver
+        :dbi.logger
         :dbi.error
         :cl-postgres)
   (:import-from :cl-postgres
@@ -62,9 +63,7 @@
 
 @export
 (defclass <dbd-postgres-query> (<dbi-query>)
-  ((name :initarg :name)
-   (%result :initarg :%result
-            :initform nil)))
+  ((name :initarg :name)))
 
 (defmacro with-handling-pg-errors (&body body)
   `(handler-case (progn ,@body)
@@ -100,6 +99,7 @@
              (query (make-instance '<dbd-postgres-query>
                                    :connection conn
                                    :name name
+                                   :sql sql
                                    :prepared (prepare-query conn-handle name sql))))
         (finalize query
                   (lambda ()
@@ -108,29 +108,33 @@
 
 (defmethod execute-using-connection ((conn <dbd-postgres-connection>) (query <dbd-postgres-query>) params)
   (with-handling-pg-errors
-    (multiple-value-bind (result count)
-        (exec-prepared (connection-handle conn)
-                       (slot-value query 'name)
-                       params
-                       ;; TODO: lazy fetching
-                       (row-reader (fields)
-                         (let ((result
-                                 (loop while (next-row)
-                                       collect (loop for field across fields
-                                                     collect (intern (field-name field) :keyword)
-                                                     collect (next-field field)))))
-                           (setf (slot-value query '%result)
-                                 result)
-                           query)))
-      (or result
-          (progn
-            (setf (slot-value conn '%modified-row-count) count)
-            (make-instance '<dbd-postgres-query>
-                           :connection conn
-                           :%result (list count)))))))
+    (let (took-ms)
+      (multiple-value-bind (result count)
+          (with-took-ms took-ms
+            (exec-prepared (connection-handle conn)
+                           (slot-value query 'name)
+                           params
+                           ;; TODO: lazy fetching
+                           (row-reader (fields)
+                             (let ((result
+                                     (loop while (next-row)
+                                           collect (loop for field across fields
+                                                         collect (intern (field-name field) :keyword)
+                                                         collect (next-field field)))))
+                               (setf (query-results query) result)
+                               query))))
+        (sql-log (query-sql query) params count took-ms)
+        (or result
+            (progn
+              (setf (slot-value conn '%modified-row-count) count)
+              (make-instance '<dbd-postgres-query>
+                             :connection conn
+                             :sql (query-sql query)
+                             :results (list count)
+                             :row-count count)))))))
 
 (defmethod fetch ((query <dbd-postgres-query>))
-  (pop (slot-value query '%result)))
+  (pop (query-results query)))
 
 (defmethod do-sql ((conn <dbd-postgres-connection>) sql &rest params)
   (if params
@@ -138,7 +142,14 @@
         (call-next-method)
         (row-count conn))
       (with-handling-pg-errors
-        (or (nth-value 1 (exec-query (connection-handle conn) sql)) 0))))
+        (let (took-ms)
+          (let ((row-count
+                  (or (nth-value 1
+                                 (with-took-ms took-ms
+                                   (exec-query (connection-handle conn) sql)))
+                      0)))
+            (sql-log sql params row-count took-ms)
+            row-count)))))
 
 (defmethod disconnect ((conn <dbd-postgres-connection>))
   (close-database (connection-handle conn)))

--- a/src/dbd/sqlite3.lisp
+++ b/src/dbd/sqlite3.lisp
@@ -77,7 +77,7 @@
           (error '<dbi-database-error>
                  :message (sqlite-error-message e)
                  :error-code (sqlite-error-code e)))))
-  (values))
+  (row-count conn))
 
 (defmethod fetch-using-connection ((conn <dbd-sqlite3-connection>) (query <dbd-sqlite3-query>))
   @ignore conn

--- a/src/dbi.lisp
+++ b/src/dbi.lisp
@@ -26,6 +26,9 @@
                 :row-count
                 :transaction-done-condition
                 :free-query-resources)
+  (:import-from :dbi.logger
+                :*sql-execution-hooks*
+                :simple-sql-logger)
   (:import-from :bordeaux-threads
                 :current-thread
                 :thread-alive-p)
@@ -59,7 +62,11 @@
            :<dbi-integrity-error>
            :<dbi-internal-error>
            :<dbi-programming-error>
-           :<dbi-notsupported-error>))
+           :<dbi-notsupported-error>
+
+           ;; logger
+           :*sql-execution-hooks*
+           :simple-sql-logger))
 (in-package :dbi)
 
 (cl-syntax:use-syntax :annot)

--- a/src/driver.lisp
+++ b/src/driver.lisp
@@ -132,7 +132,7 @@ This method may be overrided by subclasses."
 This method may be overrided by subclasses.")
   (:method ((conn <dbi-connection>) (sql string) &rest params)
     (apply #'execute (prepare conn sql) params)
-    (values)))
+    (row-count conn)))
 
 @export
 (defgeneric execute-using-connection (conn query params)

--- a/src/driver.lisp
+++ b/src/driver.lisp
@@ -73,16 +73,21 @@ Driver should be named like '<DBD-SOMETHING>' for a database 'something'."
 @export
 @export-accessors
 (defclass <dbi-query> ()
-     ((connection :type <dbi-connection>
-                  :initarg :connection
-                  :initform nil
-                  :accessor query-connection)
-      (sql :type string
-           :initarg :sql
-           :accessor query-sql)
-      (prepared :type t
-                :initarg :prepared
-                :accessor query-prepared))
+  ((connection :type <dbi-connection>
+               :initarg :connection
+               :initform nil
+               :accessor query-connection)
+   (sql :type string
+        :initarg :sql
+        :accessor query-sql)
+   (prepared :type t
+             :initarg :prepared
+             :accessor query-prepared)
+   (results :initarg :results
+            :accessor query-results)
+   (row-count :type integer
+              :initarg :row-count
+              :accessor query-row-count))
   (:documentation "Class that represents a prepared DB query."))
 
 @export
@@ -131,8 +136,9 @@ This method may be overrided by subclasses."
   (:documentation "Do preparation and execution at once.
 This method may be overrided by subclasses.")
   (:method ((conn <dbi-connection>) (sql string) &rest params)
-    (apply #'execute (prepare conn sql) params)
-    (row-count conn)))
+    (let ((query (prepare conn sql)))
+      (apply #'execute query params)
+      (query-row-count query))))
 
 @export
 (defgeneric execute-using-connection (conn query params)

--- a/src/logger.lisp
+++ b/src/logger.lisp
@@ -1,0 +1,31 @@
+(defpackage dbi.logger
+  (:use :cl)
+  (:export :*sql-execution-hooks*
+           :simple-sql-logger
+           :sql-log
+           :with-took-ms))
+(in-package :dbi.logger)
+
+(defvar *sql-execution-hooks* '())
+
+(defun simple-sql-logger (sql params row-count took-ms)
+  (format t "~&~<;;~@; ~A (~{~S~^, ~}) ~@[[~D row~:P]~]~@[ (~Dms)~]~:>~%"
+          (list sql
+                (mapcar (lambda (param)
+                          (if (typep param '(simple-array (unsigned-byte 8) (*)))
+                              (map 'string #'code-char param)
+                              param))
+                        params)
+                row-count
+                took-ms)))
+
+(defun sql-log (sql params row-count took-ms)
+  (dolist (hook-fn *sql-execution-hooks*)
+    (funcall hook-fn sql params row-count took-ms))
+  (values))
+
+(defmacro with-took-ms (took-ms &body body)
+  (let ((before (gensym "BEFORE")))
+    `(let ((,before (get-internal-real-time)))
+       (multiple-value-prog1 (progn ,@body)
+         (setf ,took-ms (- (get-internal-real-time) ,before))))))

--- a/src/test.lisp
+++ b/src/test.lisp
@@ -24,13 +24,13 @@
   (is-type *db* '<dbi-connection>))
 
 (deftest |do-sql|
-  (is (do-sql *db* "DROP TABLE IF EXISTS person") nil)
+  (is (do-sql *db* "DROP TABLE IF EXISTS person") 0)
   (is (do-sql *db* "CREATE TABLE person (id INTEGER PRIMARY KEY, name VARCHAR(24) NOT NULL)")
-      nil)
+      0)
   (is (do-sql *db* "INSERT INTO person (id, name) VALUES (1, 'fukamachi')")
-      nil)
+      1)
   (is (do-sql *db* "INSERT INTO person (id, name) VALUES (2, 'matsuyama')")
-      nil))
+      1))
 
 (deftest |prepare, execute & fetch|
   (let (query result)


### PR DESCRIPTION
This patch allows to add hooks when SQL execution by adding a function to `dbi:*sql-execution-hooks*`.

The hook function takes these 4 values:

- SQL (string)
- placeholder parameters (list)
- Row count of the results (integer or null)
- Took time in miliseconds (integer or null)

Row count and took time could be null if those values are not available for the driver in some reason.

`dbi:simple-sql-logger` is also provided for just printing those values to `*standard-output*`.