### PR TITLE
Refactored the way how transactions and savepoints are handled.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -150,6 +150,78 @@ The row count and its took time could be null if those values are not available 
 (push #'dbi:simple-sql-logger dbi:*sql-execution-hooks*)
 ```
 
+## Development
+
+### Running all tests in the Docker
+
+This will not require you to install Postgres or Mysql.
+All you need is Docker and Docker Compose.
+
+To run all tests, execute this in the shell:
+
+    docker-compose up tests
+
+### Running specific driver's unittests
+
+Running tests with docker-compose does not allow you
+to debug code in SLIME or SLY. To do this, you need
+to start databases as separate containers and to make
+their ports available to the host machine.
+
+Here is how you can start Postgres and Mysql in Docker
+and run unittests agains them:
+
+* Start a docker container with the database
+
+  For example, with postgres:
+
+      docker run --rm -ti \
+             -e POSTGRES_USER=cl-dbi \
+             -e POSTGRES_PASSWORD=cl-dbi \
+             -p 5432:5432 \
+             postgres:10
+
+  Or with mysql:
+
+      docker run --rm -ti \
+             --name cl-dbi \
+             -e MYSQL_ROOT_PASSWORD=cl-dbi \
+             -p 3306:3306 \
+             mysql:8
+
+      docker exec -ti \
+             cl-dbi \
+             mysql -pcl-dbi \
+                   -e 'create database if not exists `cl-dbi`'
+
+* Then in Lisp repl load the unittests:
+
+      (ql:quickload :dbi-test)
+      ;; Turn off colors if you are in the Emacs
+      (setf prove:*enable-colors* nil)
+      ;; Set this to debug failed test
+      (setf prove:*debug-on-error* t)
+
+* And start driver's unittests:
+
+  For postgres:
+
+      (dbi.test:run-driver-tests :postgres
+                                 :database-name "postgres"
+                                 :host "localhost"
+                                 :port 5432
+                                 :username "cl-dbi"
+                                 :password "cl-dbi")
+
+  For mysql:
+
+      (dbi.test:run-driver-tests :mysql
+                                 :database-name "cl-dbi"
+                                 :host "127.0.0.1"
+                                 :port 3306
+                                 :username "root"
+                                 :password "cl-dbi")
+
 ## Author
 
 * Eitaro Fukamachi (e.arrows@gmail.com)

--- a/README.markdown
+++ b/README.markdown
@@ -215,12 +215,27 @@ and run unittests agains them:
 
   For mysql:
 
+      ;; Probably you will need to load library manually if
+      ;; it was installed using Homebrew:
+      (push "/usr/local/opt/mysql-client/lib/" cffi:*foreign-library-directories*)
+      (cffi:load-foreign-library "libmysqlclient.20.dylib"
+                                 :search-path "/usr/local/opt/mysql-client/lib/")
       (dbi.test:run-driver-tests :mysql
                                  :database-name "cl-dbi"
                                  :host "127.0.0.1"
                                  :port 3306
                                  :username "root"
                                  :password "cl-dbi")
+
+  Also, you can run a single test like this:
+  
+      (dbi.test:run-driver-tests :mysql
+                                 :database-name "cl-dbi"
+                                 :host "127.0.0.1"
+                                 :port 3306
+                                 :username "root"
+                                 :password "cl-dbi"
+                                 :test-name '|select-after-commit|)
 
 ## Author
 

--- a/dbi-test.asd
+++ b/dbi-test.asd
@@ -15,6 +15,7 @@
                :prove
                :closer-mop
                :cl-syntax
+               :alexandria
                :cl-syntax-annot
                :trivial-types)
   :components ((:module "src"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '3.7'
+services:
+  tests:
+    container_name: cl-dbi-tests
+    build:
+      dockerfile: docker/Dockerfile
+      context: .
+      target: base
+    restart: "no"
+    volumes:
+      - ./:/app/
+    depends_on:
+      - postgres
+      - mysql
+    environment:
+      # SKIP_MYSQL: 1
+      # SKIP_POSTGRES: 1
+      # SKIP_SQLITE3: 1
+
+      POSTGRES_HOST: postgres
+      POSTGRES_USER: cl-dbi
+      POSTGRES_PASS: cl-dbi
+      MYSQL_HOST: mysql
+      MYSQL_USER: root
+      MYSQL_PASS: cl-dbi
+
+  postgres:
+    container_name: cl-dbi-postgres
+    image: "postgres:10"
+    restart: always
+    environment:
+      POSTGRES_USER: cl-dbi
+      POSTGRES_PASSWORD: cl-dbi
+
+  mysql:
+    container_name: cl-dbi-mysql
+    image: "mysql:8"
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: cl-dbi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       - postgres
       - mysql
     environment:
+      # LISP: ccl-bin
+
       # SKIP_MYSQL: 1
       # SKIP_POSTGRES: 1
       # SKIP_SQLITE3: 1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,13 @@
+FROM 40ants/base-lisp-image:0.9.0-sbcl-bin as base
+
+RUN ros install prove
+RUN apt-get update && \
+    apt-get install -y libmysqlclient20 mysql-client && \
+    ln -s /usr/lib/x86_64-linux-gnu/libmysqlclient.so.20 /usr/lib/x86_64-linux-gnu/libmysqlclient_r.so
+
+COPY . /app
+WORKDIR /app
+
+ENV CL_SOURCE_REGISTRY "/app/"
+
+CMD /app/docker/entrypoint.sh

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -3,6 +3,8 @@
 set -x
 set -e
 
+: ${LISP:=sbcl-bin}
+
 while ! mysql -u "$MYSQL_USER" \
         -h "$MYSQL_HOST" \
         -P "$MYSQL_PORT" \
@@ -11,4 +13,6 @@ while ! mysql -u "$MYSQL_USER" \
       sleep 1
 done
 
+ros install "$LISP"
+ros use "$LISP"
 /root/.roswell/bin/run-prove dbi-test.asd

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -x
+set -e
+
+while ! mysql -u "$MYSQL_USER" \
+        -h "$MYSQL_HOST" \
+        -P "$MYSQL_PORT" \
+        -p"$MYSQL_PASS" \
+        -e 'CREATE DATABASE IF NOT EXISTS `cl-dbi`'; do \
+      sleep 1
+done
+
+/root/.roswell/bin/run-prove dbi-test.asd

--- a/src/dbd/sqlite3.lisp
+++ b/src/dbd/sqlite3.lisp
@@ -6,8 +6,9 @@
         :dbi.error
         :sqlite
         :annot.class)
-  (:shadowing-import-from :dbi.driver
-                          :disconnect)
+  (:shadowing-import-from #:dbi.driver
+                          #:disconnect
+                          #:with-transaction)
   (:import-from :trivial-garbage
                 :finalize)
   (:import-from :uiop/filesystem

--- a/src/dbi.lisp
+++ b/src/dbi.lisp
@@ -3,71 +3,73 @@
   (:use :cl
         :dbi.error)
   (:nicknames :cl-dbi)
-  (:import-from :dbi.driver
-                :list-all-drivers
-                :find-driver
-                :connection-driver-type
-                :connection-database-name
-                :make-connection
-                :disconnect
-                :prepare
-                :execute
-                :fetch
-                :fetch-all
-                :do-sql
-                :begin-transaction
-                :commit
-                :rollback
-                :savepoint
-                :rollback-savepoint
-                :release-savepoint
-                :*in-transaction*
-                :*current-savepoint*
-                :ping
-                :row-count
-                :transaction-done-condition
-                :free-query-resources)
-  (:import-from :dbi.logger
-                :*sql-execution-hooks*
-                :simple-sql-logger)
-  (:import-from :bordeaux-threads
-                :current-thread
-                :thread-alive-p)
-  (:export :list-all-drivers
-           :find-driver
-           :connection-driver-type
-           :connection-database-name
-           :disconnect
-           :prepare
-           :execute
-           :fetch
-           :fetch-all
-           :do-sql
-           :begin-transaction
-           :commit
-           :rollback
-           :savepoint
-           :rollback-savepoint
-           :release-savepoint
-           :ping
-           :row-count
-           :free-query-resources
+  (:import-from #:dbi.driver
+                #:list-all-drivers
+                #:find-driver
+                #:connection-driver-type
+                #:connection-database-name
+                #:make-connection
+                #:disconnect
+                #:prepare
+                #:execute
+                #:fetch
+                #:fetch-all
+                #:do-sql
+                #:begin-transaction
+                #:commit
+                #:rollback
+                #:savepoint
+                #:rollback-savepoint
+                #:release-savepoint
+                #:with-savepoint
+                #:with-transaction
+                #:ping
+                #:row-count
+                #:transaction-done-condition
+                #:free-query-resources)
+  (:import-from #:dbi.logger
+                #:*sql-execution-hooks*
+                #:simple-sql-logger)
+  (:import-from #:bordeaux-threads
+                #:current-thread
+                #:thread-alive-p)
+  (:export #:list-all-drivers
+           #:find-driver
+           #:connection-driver-type
+           #:connection-database-name
+           #:disconnect
+           #:prepare
+           #:execute
+           #:fetch
+           #:fetch-all
+           #:do-sql
+           #:begin-transaction
+           #:commit
+           #:rollback
+           #:savepoint
+           #:rollback-savepoint
+           #:release-savepoint
+           #:with-savepoint
+           #:with-transaction
+           #:ping
+           #:row-count
+           #:free-query-resources
 
-           :<dbi-error>
-           :<dbi-warning>
-           :<dbi-interface-error>
-           :<dbi-unimplemented-error>
-           :<dbi-database-error>
-           :<dbi-data-error>
-           :<dbi-operational-error>
-           :<dbi-integrity-error>
-           :<dbi-internal-error>
-           :<dbi-programming-error>
-           :<dbi-notsupported-error>
+           #:<dbi-error>
+           #:<dbi-warning>
+           #:<dbi-interface-error>
+           #:<dbi-unimplemented-error>
+           #:<dbi-database-error>
+           #:<dbi-data-error>
+           #:<dbi-operational-error>
+           #:<dbi-integrity-error>
+           #:<dbi-internal-error>
+           #:<dbi-programming-error>
+           #:<dbi-notsupported-error>
 
            ;; logger
-           :*sql-execution-hooks*
-           :simple-sql-logger))
+           #:*sql-execution-hooks*
+           #:simple-sql-logger))
 (in-package :dbi)
 
 (cl-syntax:use-syntax :annot)
@@ -160,60 +162,6 @@
     #-quicklisp
     (asdf:load-system driver-system :verbose nil)))
 
-(defun generate-random-savepoint ()
-  (format nil "savepoint_~36R" (random (expt 36 #-gcl 8 #+gcl 5))))
-
-@export
-(defmacro with-savepoint (conn &body body)
-  (let ((done (gensym "SAVEPOINT-DONE"))
-        (ok (gensym "SAVEPOINT-OK"))
-        (conn-var (gensym "CONN-VAR")))
-    `(let* (,done
-            ,ok
-            (,conn-var ,conn)
-            (*current-savepoint* (generate-random-savepoint)))
-       (savepoint ,conn-var *current-savepoint*)
-       (unwind-protect
-            (handler-case (multiple-value-prog1
-                              (progn ,@body)
-                            (setf ,ok t))
-              (transaction-done-condition () (setf ,done t)))
-         (unless ,done
-           (handler-case
-               (if ,ok
-                   (release-savepoint ,conn-var)
-                   (rollback-savepoint ,conn-var))
-             (transaction-done-condition ())))))))
-
-(defmacro %with-transaction (conn &body body)
-  (let ((done (gensym "TRANSACTION-DONE"))
-        (ok (gensym "TRANSACTION-OK"))
-        (conn-var (gensym "CONN-VAR")))
-    `(let* (,done
-            ,ok
-            (,conn-var ,conn)
-            (*in-transaction* (cons ,conn-var *in-transaction*)))
-       (begin-transaction ,conn-var)
-       (unwind-protect
-            (handler-case (multiple-value-prog1
-                              (progn ,@body)
-                            (setf ,ok t))
-              (transaction-done-condition () (setf ,done t)))
-         (unless ,done
-           (handler-case
-               (if ,ok
-                   (commit ,conn-var)
-                   (rollback ,conn-var))
-             (transaction-done-condition ())))))))
-
-@export
-(defmacro with-transaction (conn &body body)
-  "Start a transaction and commit at the end of this block. If the evaluation `body` is interrupted, the transaction is rolled back automatically."
-  (let ((conn-var (gensym "CONN-VAR")))
-    `(let ((,conn-var ,conn))
-       (if (find ,conn-var *in-transaction* :test #'eq)
-           (with-savepoint ,conn-var ,@body)
-           (%with-transaction ,conn-var ,@body)))))
 
 @export
 (defmacro with-connection ((conn-sym &rest rest) &body body)

--- a/src/dbi.lisp
+++ b/src/dbi.lisp
@@ -16,6 +16,7 @@
                 #:fetch-all
                 #:do-sql
                 #:begin-transaction
+                #:in-transaction
                 #:commit
                 #:rollback
                 #:savepoint
@@ -44,6 +45,7 @@
            #:fetch-all
            #:do-sql
            #:begin-transaction
+           #:in-transaction
            #:commit
            #:rollback
            #:savepoint

--- a/src/driver.lisp
+++ b/src/driver.lisp
@@ -202,6 +202,7 @@ This method must be implemented in each drivers.")
         :key #'get-conn))
 
 
+@export
 (defun in-transaction (conn)
   "Returns True if called inside a transaction block."
   (not (null (get-transaction-state conn))))

--- a/src/driver.lisp
+++ b/src/driver.lisp
@@ -179,7 +179,7 @@ This method must be implemented in each drivers.")
 (define-condition transaction-done-condition () ())
 
 (defclass <transaction-state> ()
-  ((conn :type '<dbi-connection>
+  ((conn :type <dbi-connection>
          :initarg :conn
          :reader get-conn)
    (state :initform :in-progress

--- a/src/error.lisp
+++ b/src/error.lisp
@@ -80,3 +80,14 @@ support transactions.")
      (format stream
              "`~A' isn't supported on the current driver."
              (slot-value condition 'method-name)))))
+
+@export
+(define-condition <dbi-already-commited-error> (<dbi-error>) ()
+  (:documentation "This exception occur when there is a programming error and
+you are trying to commit a transaction twice."))
+
+@export
+(define-condition <dbi-already-rolled-back-error> (<dbi-error>) ()
+  (:documentation "This exception occur when there is a programming error and
+you are trying to rollback a transaction twice."))
+

--- a/src/logger.lisp
+++ b/src/logger.lisp
@@ -28,8 +28,7 @@
   (let ((before (gensym "BEFORE")))
     `(let ((,before (get-internal-real-time)))
        (multiple-value-prog1 (progn ,@body)
-         (setf ,took-ms (coerce
+         (setf ,took-ms (ceiling
                          (/ (* (- (get-internal-real-time) ,before)
                                1000)
-                            internal-time-units-per-second)
-                         'integer))))))
+                            internal-time-units-per-second)))))))

--- a/src/logger.lisp
+++ b/src/logger.lisp
@@ -28,4 +28,8 @@
   (let ((before (gensym "BEFORE")))
     `(let ((,before (get-internal-real-time)))
        (multiple-value-prog1 (progn ,@body)
-         (setf ,took-ms (- (get-internal-real-time) ,before))))))
+         (setf ,took-ms (coerce
+                         (/ (* (- (get-internal-real-time) ,before)
+                               1000)
+                            internal-time-units-per-second)
+                         'integer))))))

--- a/src/test.lisp
+++ b/src/test.lisp
@@ -15,7 +15,10 @@
 @export
 (defun run-driver-tests (driver-name &rest params)
   (let ((*package* (find-package :dbi.test))
-        (env-var (format nil "SKIP_~A" driver-name)))
+        (env-var (format nil "SKIP_~A" driver-name))
+        (test-name (getf params :test-name)))
+    (alexandria:remove-from-plistf params :test-name)
+    
     (cond
       ((uiop:getenv env-var)
        (plan 0)
@@ -25,7 +28,9 @@
        (let ((*db* (apply #'connect driver-name params))
              (*driver-name* driver-name))
          (unwind-protect
-              (run-test-package :dbi.test)
+              (if test-name
+                  (run-test test-name)
+                  (run-test-package :dbi.test))
            (disconnect *db*)))))))
 
 

--- a/src/test.lisp
+++ b/src/test.lisp
@@ -15,10 +15,35 @@
 (defun run-driver-tests (driver-name &rest params)
   (let ((*db* (apply #'connect driver-name params))
         (*package* (find-package :dbi.test)))
-    (plan 6)
+    (plan 10)
     (unwind-protect
          (run-test-package :dbi.test)
       (disconnect *db*))))
+
+
+(defmacro with-collected-queries (&body body)
+  "Collects all sql queries produced by the body.
+   makes function (get-queries) available in the scope of the block."
+  (let ((queries-var (gensym "QUERIES")))
+    `(let* (,queries-var
+            (dbi:*sql-execution-hooks*
+              (cons (lambda (query &rest args)
+                      (declare (ignorable args))
+                      (format t "QUERY: ~A~%" query)
+                      (push query ,queries-var))
+                    dbi:*sql-execution-hooks*)))
+       (flet ((get-queries ()
+                (reverse ,queries-var)))
+         ,@body))))
+
+
+;; Don't know. Why dbi:fetch-all does not work this way?
+(defun execute-and-fetch-all (conn sql &rest params)
+  (fetch-all
+   (apply #'execute
+          (prepare conn sql)
+          params)))
+
 
 (deftest |connect|
   (is-type *db* '<dbi-connection>))
@@ -75,6 +100,69 @@
           (do-sql *db* "INSERT INTO person (id, name) VALUES (4, 'meymao')"))
         (is (fetch (execute (prepare *db* "SELECT * FROM person WHERE name = 'meymao'")))
             '(:|id| 4 :|name| "meymao")))
+    (dbi.error:<dbi-notsupported-error> ()
+      (skip 1 "Not supported"))))
+
+(deftest |with-nested-transaction|
+  "Nested transactions should be transformed into savepoints"
+  (handler-case
+      (flet ((get-row-number ()
+               (getf (first
+                      (execute-and-fetch-all *db* "SELECT COUNT(*) as CNT FROM person"))
+                     :cnt)))
+        (with-transaction *db*
+          (do-sql *db* "DROP TABLE IF EXISTS person")
+          (do-sql *db* "CREATE TABLE person (id INTEGER PRIMARY KEY, name VARCHAR(24) NOT NULL)")
+
+          (do-sql *db* "INSERT INTO person (id, name) VALUES (1, 'foo')")
+          (with-transaction *db*
+            (do-sql *db* "INSERT INTO person (id, name) VALUES (2, 'bar')")
+            ;;
+            (ok (= (get-row-number) 2)
+                "At this stage there should be two items in the database")
+
+            ;; This should rollback the second INSERT
+            (rollback *db*)
+
+            (ok (= (get-row-number) 1)
+                "And now we have only one row"))))
+
+    (dbi.error:<dbi-notsupported-error> ()
+      (skip 1 "Not supported"))))
+
+(deftest |duplicate-rollback|
+  (handler-case
+      (with-transaction *db*
+        (rollback *db*)
+        ;; Second rollback should fail
+        (prove:is-error (rollback *db*)
+                        'dbi.error:<dbi-already-rolled-back-error>
+                        "Duplicate rollback should raise an error"))
+
+    (dbi.error:<dbi-notsupported-error> ()
+      (skip 1 "Not supported"))))
+
+(deftest |duplicate-commit|
+  (handler-case
+      (with-transaction *db*
+        (commit *db*)
+        ;; Second rollback should fail
+        (prove:is-error (commit *db*)
+                        'dbi.error:<dbi-already-commited-error>
+                        "Duplicate commit should raise an error"))
+
+    (dbi.error:<dbi-notsupported-error> ()
+      (skip 1 "Not supported"))))
+
+(deftest |code-execution-after-manual-commit|
+  (handler-case
+      (let (value)
+        (with-transaction *db*
+          (commit *db*)
+          (setf value :foo))
+        (ok (eql value :foo)
+            "Value should be set to foo even after the manual commit."))
+
     (dbi.error:<dbi-notsupported-error> ()
       (skip 1 "Not supported"))))
 

--- a/src/test.lisp
+++ b/src/test.lisp
@@ -108,8 +108,8 @@
   (handler-case
       (flet ((get-row-number ()
                (getf (first
-                      (execute-and-fetch-all *db* "SELECT COUNT(*) as CNT FROM person"))
-                     :cnt)))
+                      (execute-and-fetch-all *db* "SELECT COUNT(*) as cnt FROM person"))
+                     :|cnt|)))
         (with-transaction *db*
           (do-sql *db* "DROP TABLE IF EXISTS person")
           (do-sql *db* "CREATE TABLE person (id INTEGER PRIMARY KEY, name VARCHAR(24) NOT NULL)")

--- a/t/dbd/mysql.lisp
+++ b/t/dbd/mysql.lisp
@@ -5,4 +5,14 @@
         :dbi))
 (in-package :dbd-mysql-test)
 
-(dbi.test:run-driver-tests :mysql :database-name "cl-dbi" :username "nobody" :password "nobody")
+(dbi.test:run-driver-tests :mysql
+                           :database-name "cl-dbi"
+                           :host (or (uiop:getenv "MYSQL_HOST")
+                                     "localhost")
+                           :port (parse-integer
+                                  (or (uiop:getenv "MYSQL_PORT")
+                                      "3306"))
+                           :username (or (uiop:getenv "MYSQL_USER")
+                                         "nobody")
+                           :password (or (uiop:getenv "MYSQL_PASS")
+                                         "nobody"))

--- a/t/dbd/postgres.lisp
+++ b/t/dbd/postgres.lisp
@@ -5,4 +5,15 @@
         :dbi.test))
 (in-package :dbd-postgres-test)
 
-(dbi.test:run-driver-tests :postgres :database-name "cl-dbi" :username "nobody" :password "nobody")
+(dbi.test:run-driver-tests :postgres
+                           :database-name (or (uiop:getenv "POSTGRES_DBNAME")
+                                              "cl-dbi")
+                           :host (or (uiop:getenv "POSTGRES_HOST")
+                                     "localhost")
+                           :port (parse-integer
+                                  (or (uiop:getenv "POSTGRES_PORT")
+                                      "5432"))
+                           :username (or (uiop:getenv "POSTGRES_USER")
+                                         "nobody")
+                           :password (or (uiop:getenv "POSTGRES_PASS")
+                                         "nobody"))


### PR DESCRIPTION
Now their state is stored in small structures and at any point of time it possible to know if the transaction already was committed or rolled back.

Also, the issue https://github.com/fukamachi/cl-dbi/issues/49 about non-local exit from `dbi:commit` function. Now control flow continues after the manuall call to `dbi:commit`. But second manual call to `dbi:commit` or `dbi:rollback` will cause error.

### Other changes

* Fixed macro `with-took-ms`. Now it really report in milliseconds.
  Previously, macro returned the value in internal units which on some implementation may be equal to milliseconds.
* Now `sqlite3` driver logs sql queries the same way as postgresql does.

