### PR TITLE
Converts Calls With Parameters to `&optional` instead of `&rest`

### DIFF
--- a/src/dbd/mysql.lisp
+++ b/src/dbd/mysql.lisp
@@ -87,7 +87,7 @@
          (result
            (with-error-handler conn
              (with-took-ms took-ms
-               (query (apply (query-prepared query) params)
+               (query (funcall (query-prepared query) params)
                       :database (connection-handle conn)
                       :store nil)))))
     (return-or-close (owner-pool result) result)

--- a/src/dbd/postgres.lisp
+++ b/src/dbd/postgres.lisp
@@ -142,7 +142,7 @@
 (defmethod fetch ((query dbd-postgres-query))
   (pop (query-results query)))
 
-(defmethod do-sql ((conn dbd-postgres-connection) sql &rest params)
+(defmethod do-sql ((conn dbd-postgres-connection) sql &optional params)
   (if params
       (progn
         (call-next-method)

--- a/src/dbd/sqlite3.lisp
+++ b/src/dbd/sqlite3.lisp
@@ -77,11 +77,11 @@
       (t (sql-log (query-sql query) params nil nil)))
     query))
 
-(defmethod do-sql ((conn dbd-sqlite3-connection) (sql string) &rest params)
+(defmethod do-sql ((conn dbd-sqlite3-connection) (sql string) &optional params)
   (let (took-ms)
     (handler-case
         (with-took-ms took-ms
-          (apply #'execute-non-query (connection-handle conn) sql params))
+          (sqlite:execute-non-query (connection-handle conn) sql params))
       (sqlite-error (e)
         (if (eq (sqlite-error-code e) :error)
             (error 'dbi-programming-error


### PR DESCRIPTION
Passing large numbers of arguments within a `&rest` variable is not
very portable Common Lisp because of
[call-arguments-limit](http://www.lispworks.com/documentation/HyperSpec/Body/v_call_a.htm).

For performance reasons, users may want many bind parameters to take
advantage of so-called extended inserts, e.g.:

`INSERT INTO tbl_name (a,b,c) VALUES(?,?,?),(?,?,?),(?,?,?),(?,?,?),...`

When this is the case, cl-dbi is artificially coupling how many `&rest`
parameters can be passed with how many extended inserts a DB can
support thus potentially artificially limiting an application's
performance. Further, it becomes more difficult to write portable code
because of this implementation detail.

fixes #60 