### PR TITLE
Fix dbi:ping for PostgreSQL.

### DIFF
--- a/src/dbd/postgres.lisp
+++ b/src/dbd/postgres.lisp
@@ -192,7 +192,9 @@
              (progn
                (cl-postgres::send-parse (cl-postgres::connection-socket handle)
                                         (symbol-name (gensym "PING"))
-                                        "")
+                                        ""
+                                        nil
+                                        nil)
                t))
       ((or cl-postgres-error:admin-shutdown
            cl-postgres-error:crash-shutdown


### PR DESCRIPTION
The parameters of send-parse was changed at https://github.com/marijnh/Postmodern/commit/3552ec2418e939930cc64719663017d7d0e4cd33.