### PR TITLE
README: mention the db drivers (required for binaries)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -96,6 +96,18 @@ To load "cl-dbi":
 (:CL-DBI)
 ```
 
+cl-dbi will load another system on the fly depending on your database's
+driver:
+
+    :dbd-sqlite3
+    :dbd-mysql
+    :dbd-postgres
+
+You must reference the required one in your system definition if you
+plan to build an executable (and if you plan to run it on a machine
+where Quicklisp is not installed).
+
+
 ## API
 
 ### User-Level API


### PR DESCRIPTION
I built a binary and ran it on a server. cl-dbi wanted to install dbd-sqlite3 on the fly, it called to ASDF, that didn't find the common-lisp/ directory (as expected), and failed with a useless error message.

Hopefully this addition will save someone some digging.

But also, maybe can cl-dbi print a warning that it is going to (try to) install a missing driver? `dbi.lisp`, `with-autoload-on-missing`.

Best,

[ci skip]