### PR TITLE
Support byte vectors in prepare-sql as hex literals

### DIFF
--- a/src/driver.lisp
+++ b/src/driver.lisp
@@ -511,10 +511,21 @@ For example, in case of MySQL and PostgreSQL, backslashes must be escaped by dou
   (:documentation
    "Create a function that takes parameters, binds them into a query and returns SQL as a string.")
   (:method ((conn dbi-connection) (sql string))
-    (labels ((param-to-sql (param)
+    (labels ((octets-to-hex (octets)
+               (let ((hex (make-string (* 2 (length octets)))))
+                 (loop for byte across octets
+                       for i from 0 by 2
+                       for hi = (ash byte -4)
+                       for lo = (logand byte #xf)
+                       do (setf (aref hex i) (char "0123456789ABCDEF" hi)
+                                (aref hex (1+ i)) (char "0123456789ABCDEF" lo)))
+                 hex))
+             (param-to-sql (param)
                (typecase param
                  (string (concatenate 'string "'" (escape-sql conn param) "'"))
                  (null "NULL")
+                 ((vector (unsigned-byte 8))
+                  (concatenate 'string "X'" (octets-to-hex param) "'"))
                  (t (princ-to-string param)))))
       (let ((sql-parts (split-sequence #\? sql)))
         (lambda (params)

--- a/t/driver.lisp
+++ b/t/driver.lisp
@@ -64,6 +64,15 @@
                    "SELECT * FROM kyoto WHERE type = 'cafe'")
             "prepare-sql")))
 
+    (testing "prepare-sql with byte vectors"
+      (let ((query (prepare conn "INSERT INTO test (data) VALUES (?)")))
+        (ok (equal (funcall (query-prepared query) (list (make-array 4 :element-type '(unsigned-byte 8) :initial-contents '(192 123 154 125))))
+                   "INSERT INTO test (data) VALUES (X'C07B9A7D')")
+            "byte vector to hex literal")
+        (ok (equal (funcall (query-prepared query) (list (make-array 0 :element-type '(unsigned-byte 8))))
+                   "INSERT INTO test (data) VALUES (X'')")
+            "empty byte vector")))
+
     (testing "prepare-cached"
       (let ((query3 (prepare-cached conn "SELECT * FROM kyoto WHERE type = ?")))
         (ok (typep query3 'dbi-query))


### PR DESCRIPTION
## Summary

- Add `(vector (unsigned-byte 8))` case to `param-to-sql` in `prepare-sql`, converting byte vectors to SQL hex literals (`X'...'`)
- Previously, byte vectors fell through to `princ-to-string`, producing invalid SQL like `#(192 123 154 ...)`

Fixes the insertion side of fukamachi/mito#192.